### PR TITLE
Fix for makepdf refs #8

### DIFF
--- a/bin/makepdf
+++ b/bin/makepdf
@@ -268,7 +268,7 @@ function build_pdf_manual()
 #	param+='-a experimental="" ' #   experimental already set in site.yml
 	param+='-a examplesdir='$(pwd)/modules/${source_root}/examples/' '
 	param+='-a imagesdir='$(pwd)/modules/${source_root}/images/' '
-	param+='-a partialsdir='$(pwd)/modules/${source_root}/pages/_partials/' '
+	param+='-a partialsdir='$(pwd)/modules/${source_root}/partials/' '
 	param+='-a revnumber='${branch}' '
 	param+='-a revdate="'${release_date}'" '
 	param+='-a allow-uri-read="" '


### PR DESCRIPTION
Fixing a missed change in an attribute in makepdf.
References #8 (Fix the family directory structure)

No backport needed