### PR TITLE
Update branded_linux_desktop_clients.adoc

### DIFF
--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -1,9 +1,10 @@
 = Deploy And Update Branded Linux Desktop Clients
 
+:description: As an ownBrander user, you can enable the build of branded Linux in the “Desktop” section of your ownCloud account.
+
 == Introduction
 
-As an ownBrander user, you can enable the build of branded Linux in the “Desktop” section of your account. You can download a `*.tar` file which contains everything to set up complete self-hosted Linux repositories
-for the selected Linux distributions.
+{description} You can download a `*.tar` file which contains everything to set up complete self-hosted Linux repositories for the selected Linux distributions.
 
 == Setup
 
@@ -149,10 +150,13 @@ You must change example.sh before it can be run.
    - Delete (or comment out) the line containing the url.
    - Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
    - Its contents is the base URL leading up to this parent folder. +
-     E.g. if the correct --url parameter were `http://cloud.example.com/install/mycloud-2.10.0.6752-linux/` +
+     Example: if the correct `--url` parameter is: +
+     `\http://cloud.example.com/install/mycloud-2.10.0.6752-linux/` +
      then the prefix file can be created like this:
-   - `cd ...` # go to the parent folder of the unpacked archive.
-   - `echo "http://cloud.example.com/install" > .repo-admin-prefix` # this needs to be done only once.
+   - `cd ...` +
+     # go to the parent folder of the unpacked archive.
+   - `echo "http://cloud.example.com/install" > .repo-admin-prefix` +
+     # this needs to be done only once.
 
 Then execute the script with `bash example.sh` and check the `.../download/index.html` that is printed.
 

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -144,18 +144,18 @@ The url after unpacking is an internal minio url, or a non working example like 
 You must change example.sh before it can be run.
 
 * Either
-   - replace the url with the correct url leading to the exact folder in which the archive was unpacked +
+** replace the url with the correct url leading to the exact folder in which the archive was unpacked +
      (ending in `.../mycloud-2.10.0.6752-linux/` here).
 * Or 
-   - Delete (or comment out) the line containing the url.
-   - Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
-   - Its contents is the base URL leading up to this parent folder. +
+** Delete (or comment out) the line containing the url.
+** Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
+** Its contents is the base URL leading up to this parent folder. +
      Example: if the correct `--url` parameter is: +
      `\http://cloud.example.com/install/mycloud-2.10.0.6752-linux/` +
      then the prefix file can be created like this:
-   - `cd ...` +
+*** `cd ...` +
      # go to the parent folder of the unpacked archive.
-   - `echo "http://cloud.example.com/install" > .repo-admin-prefix` +
+*** `echo "http://cloud.example.com/install" > .repo-admin-prefix` +
      # this needs to be done only once.
 
 Then execute the script with `bash example.sh` and check the `.../download/index.html` that is printed.

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -143,14 +143,16 @@ The url after unpacking is an internal minio url, or a non working example like 
 You must change example.sh before it can be run.
 
 * Either
-   - replace the url with the correct url leading to the exact filder in which the archive was unpacked +
+   - replace the url with the correct url leading to the exact folder in which the archive was unpacked +
      (ending in `.../mycloud-2.10.0.6752-linux/` here).
 * Or 
    - Delete (or comment out) the line containing the url.
    - Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
-   - Its contents is the base URL leading up to this parent folder. E.g. when the URL to the unpacked archive is `http://cloud.example.com/install/mycloud-2.10.0.6752-linux` then this command can be used to create the prefix file:
+   - Its contents is the base URL leading up to this parent folder. +
+     E.g. if the correct --url parameter were `http://cloud.example.com/install/mycloud-2.10.0.6752-linux/` +
+     then the prefix file can be created like this:
    - `cd ...` # go to the parent folder of the unpacked archive.
-   - `echo "http://cloud.example.com/install/" > .repo-admin-prefix` # this needs to be done only once.
+   - `echo "http://cloud.example.com/install" > .repo-admin-prefix` # this needs to be done only once.
 
 Then execute the script with `bash example.sh` and check the `.../download/index.html` that is printed.
 

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -127,12 +127,26 @@ download/example.sh:::
 # You can customitze the main html file and re-run repo-admin.py later.
 # For a server without https support use --insecure --url http://...
 #
+set -euxo pipefail
+
 cd "$(dirname "${0}")"
-set -eux
-repo=http://download.example.com/repo
-python3 bin/repo-admin.py --url $repo -d 'download' -p '.*-client' -i 'index.html' -f ..
+
+opt=()
+
+# if a .repo-admin-prefix file is found in a parent directory, --url can be omitted
+opt+=("--url" "https://minio.owncloud.services/clients/build-linux/7270/repo/")
+
+python3 bin/repo-admin.py  "${opt[@]}" -d 'download' -p '.*-client' -i 'index.html' -f ..
 ----
 
-Replace `\http://download.example.com/repo` in the above example with the base URL of your repository (ending in `.../mycloud-2.10.0.6752-linux/` here) and save the file.
+The url after unpacking is an internal minio url, or a non working example like `\http://download.example.com/repo`.
+You must change example.sh before it can be run.
+* Either replace the url with the correct url leading to the exact filder in which the archive was unpacked (ending in `.../mycloud-2.10.0.6752-linux/` here).
+* Or 
+   - Delete (or comment out) the line containing the url.
+   - Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
+   - Its contents is the base URL leading up to this parent folder. E.g. when the URL to the unpacked archive is `http://cloud.example.com/install/mycloud-2.10.0.6752-linux` then this command can be used to create the prefix file:
+   - `cd ...` # go to the parent folder of the unpacked archive.
+   - `echo "http://cloud.example.com/install/" > .repo-admin-prefix` # this needs to be done only once.
 
-Then execute the script and check `download/index.html` on your webserver.
+Then execute the script with `bash example.sh` and check the `.../download/index.html` that is printed.

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -135,7 +135,7 @@ cd "$(dirname "${0}")"
 opt=()
 
 # if a .repo-admin-prefix file is found in a parent directory, --url can be omitted
-opt+=("--url" "https://minio.owncloud.services/clients/build-linux/7270/repo/")
+opt+=("--url" "http://download.example.com/repo")
 
 python3 bin/repo-admin.py  "${opt[@]}" -d 'download' -p '.*-client' -i 'index.html' -f ..
 ----

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -141,7 +141,10 @@ python3 bin/repo-admin.py  "${opt[@]}" -d 'download' -p '.*-client' -i 'index.ht
 
 The url after unpacking is an internal minio url, or a non working example like `\http://download.example.com/repo`.
 You must change example.sh before it can be run.
-* Either replace the url with the correct url leading to the exact filder in which the archive was unpacked (ending in `.../mycloud-2.10.0.6752-linux/` here).
+
+* Either
+   - replace the url with the correct url leading to the exact filder in which the archive was unpacked +
+     (ending in `.../mycloud-2.10.0.6752-linux/` here).
 * Or 
    - Delete (or comment out) the line containing the url.
    - Make sure there is a `.repo-admin-prefix` file in the parent folder of the unpacked archive (here next to `mycloud-2.10.0.6752-linux`)
@@ -150,3 +153,5 @@ You must change example.sh before it can be run.
    - `echo "http://cloud.example.com/install/" > .repo-admin-prefix` # this needs to be done only once.
 
 Then execute the script with `bash example.sh` and check the `.../download/index.html` that is printed.
+
+Notice: When the URL starts with `http://` then the `--insecure` option is implicit and need not be specified.

--- a/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
+++ b/modules/ROOT/pages/branded_desktop_client/branded_linux_desktop_clients.adoc
@@ -140,7 +140,7 @@ opt+=("--url" "http://download.example.com/repo")
 python3 bin/repo-admin.py  "${opt[@]}" -d 'download' -p '.*-client' -i 'index.html' -f ..
 ----
 
-The url after unpacking is an internal minio url, or a non working example like `\http://download.example.com/repo`.
+The url after unpacking is an invalid url.
 You must change example.sh before it can be run.
 
 * Either


### PR DESCRIPTION
Since repo-admin.py 1.38, we have two new features:
- automatic detection of --insecure
- no more --url needed, when a proper .repo-admin-prefix file exists.